### PR TITLE
Add owning_ref support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/rust-osdev/spinning_top"
 
 [features]
 nightly = ["lock_api/nightly"]
+owning_ref = ["lock_api/owning_ref"]
 
 [dependencies]
 lock_api = "0.4.0"


### PR DESCRIPTION
The `lock_api` has a feature that allows support for the `owning_ref` crate. This pull request simply adds a feature gate to this crate that enables the `owning_ref` feature in the `lock_api` crate.