### PR TITLE
Upgrade lock_api to 0.4.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ repository = "https://github.com/rust-osdev/spinning_top"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-nightly = ["lock_api/nightly"]
+# Deprecated - has no effect
+nightly = []
 owning_ref = ["lock_api/owning_ref"]
 
 [dependencies]
-lock_api = "0.4.0"
+lock_api = "0.4.7"
 
 [package.metadata.release]
 no-dev-version = true

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Upgrade `lock_api` to 0.4.7. This makes `Spinlock::new` a `const` function without needing nightly rust.
+
 # 0.2.4 – 2021-05-13
 
 - Define `MappedSpinlockGuard` alias [#12](https://github.com/rust-osdev/spinning_top/pull/12)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,7 @@ fn make_uppercase(spinlock: &Spinlock<String>) {
 }
 ```
 
-## The `nightly` Feature
-
-On Rust nightly, the `nightly` feature of this crate can be enabled to 
-make the `Spinlock::new` function a `const` function. This makes the `Spinlock` type
+`Spinlock::new` is a `const` function. This makes the `Spinlock` type
 usable in statics:
 
 ```rust

--- a/src/spinlock.rs
+++ b/src/spinlock.rs
@@ -116,10 +116,9 @@ unsafe impl RawMutex for RawSpinlock {
 /// }
 /// ```
 ///
-/// ## Nightly Example
+/// ## Usage in statics
 ///
-/// On Rust nightly, the `nightly` feature of this crate can be enabled to
-/// make the `new` function a `const` function. This makes the `Spinlock` type
+/// `Spinlock::new` is a `const` function. This makes the `Spinlock` type
 /// usable in statics:
 ///
 /// ```rust,ignore


### PR DESCRIPTION
This makes `Spinlock::new` a `const` function without needing nightly rust.