### PR TITLE
ci: build with all features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
     - name: "Run cargo build"
       run: cargo build
 
+    - name: "Run cargo build --all-features"
+      run: cargo build --all-features
+
     - name: "Run cargo test"
       run: cargo test
     


### PR DESCRIPTION
Extracted from https://github.com/rust-osdev/spinning_top/pull/16, now that that PR does not need features anymore. Still, this might generally be good to test in CI.