### PR TITLE
chore: remove `const_spinlock` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,6 @@
 /// The spinlock implemenation is based on the abstractions provided by the `lock_api` crate.
 pub use lock_api;
 
-pub use spinlock::{const_spinlock, MappedSpinlockGuard, RawSpinlock, Spinlock, SpinlockGuard};
+pub use spinlock::{MappedSpinlockGuard, RawSpinlock, Spinlock, SpinlockGuard};
 
 mod spinlock;

--- a/src/spinlock.rs
+++ b/src/spinlock.rs
@@ -193,20 +193,6 @@ pub type SpinlockGuard<'a, T> = lock_api::MutexGuard<'a, RawSpinlock, T>;
 /// ```
 pub type MappedSpinlockGuard<'a, T> = lock_api::MappedMutexGuard<'a, RawSpinlock, T>;
 
-/// Create an unlocked `Spinlock` in a `const` context.
-///
-/// ## Example
-///
-/// ```rust
-/// use spinning_top::{const_spinlock, Spinlock};
-///
-/// static SPINLOCK: Spinlock<i32> = const_spinlock(42);
-/// ```
-#[inline]
-pub const fn const_spinlock<T>(val: T) -> Spinlock<T> {
-    Spinlock::const_new(<RawSpinlock as lock_api::RawMutex>::INIT, val)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
`lock_api::Mutex::new` is `const` nowadays.