### PR TITLE
feat: add `arc_lock` feature and typedefs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rust-osdev/spinning_top"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+arc_lock = ["lock_api/arc_lock"]
 owning_ref = ["lock_api/owning_ref"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ license = "MIT/Apache-2.0"
 description = "A simple spinlock crate based on the abstractions provided by `lock_api`."
 repository = "https://github.com/rust-osdev/spinning_top"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
 arc_lock = ["lock_api/arc_lock"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,11 +62,19 @@ pub use spinlock::{BackoffSpinlock, RawSpinlock, Spinlock};
 
 /// Type aliases for guards.
 pub mod guard {
+    #[cfg(feature = "arc_lock")]
+    pub use super::rw_spinlock::{
+        ArcBackoffRwSpinlockReadGuard, ArcBackoffRwSpinlockUpgradableReadGuard,
+        ArcBackoffRwSpinlockWriteGuard, ArcRwSpinlockReadGuard, ArcRwSpinlockUpgradableReadGuard,
+        ArcRwSpinlockWriteGuard,
+    };
     pub use super::rw_spinlock::{
         BackoffRwSpinlockReadGuard, BackoffRwSpinlockUpgradableReadGuard,
         BackoffRwSpinlockWriteGuard, RwSpinlockReadGuard, RwSpinlockUpgradableReadGuard,
         RwSpinlockWriteGuard,
     };
+    #[cfg(feature = "arc_lock")]
+    pub use super::spinlock::{ArcBackoffSpinlockGuard, ArcSpinlockGuard};
     pub use super::spinlock::{
         BackoffSpinlockGuard, MappedBackoffSpinlockGuard, MappedSpinlockGuard, SpinlockGuard,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 //! ```
 
 #![cfg_attr(not(test), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 

--- a/src/rw_spinlock.rs
+++ b/src/rw_spinlock.rs
@@ -232,6 +232,19 @@ pub type RwSpinlockUpgradableReadGuard<'a, T> =
 /// A [`lock_api::RwLockWriteGuard`] based on [`RawRwSpinlock`].
 pub type RwSpinlockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RawRwSpinlock<Spin>, T>;
 
+/// A [`lock_api::ArcRwLockReadGuard`] based on [`RawRwSpinlock`].
+#[cfg(feature = "arc_lock")]
+pub type ArcRwSpinlockReadGuard<T> = lock_api::ArcRwLockReadGuard<RawRwSpinlock<Spin>, T>;
+
+/// A [`lock_api::ArcRwLockUpgradableReadGuard`] based on [`RawRwSpinlock`].
+#[cfg(feature = "arc_lock")]
+pub type ArcRwSpinlockUpgradableReadGuard<T> =
+    lock_api::ArcRwLockUpgradableReadGuard<RawRwSpinlock<Spin>, T>;
+
+/// A [`lock_api::ArcRwLockWriteGuard`] based on [`RawRwSpinlock`].
+#[cfg(feature = "arc_lock")]
+pub type ArcRwSpinlockWriteGuard<T> = lock_api::ArcRwLockWriteGuard<RawRwSpinlock<Spin>, T>;
+
 /// A [`lock_api::RwLock`] based on [`RawRwSpinlock`]`<`[`Backoff`]`>`.
 pub type BackoffRwSpinlock<T> = lock_api::RwLock<RawRwSpinlock<Backoff>, T>;
 
@@ -246,6 +259,20 @@ pub type BackoffRwSpinlockUpgradableReadGuard<'a, T> =
 /// A [`lock_api::RwLockWriteGuard`] based on [`RawRwSpinlock`]`<`[`Backoff`]`>`.
 pub type BackoffRwSpinlockWriteGuard<'a, T> =
     lock_api::RwLockWriteGuard<'a, RawRwSpinlock<Backoff>, T>;
+
+/// A [`lock_api::ArcRwLockReadGuard`] based on [`RawRwSpinlock`]`<`[`Backoff`]`>`.
+#[cfg(feature = "arc_lock")]
+pub type ArcBackoffRwSpinlockReadGuard<T> = lock_api::ArcRwLockReadGuard<RawRwSpinlock<Backoff>, T>;
+
+/// A [`lock_api::ArcRwLockUpgradableReadGuard`] based on [`RawRwSpinlock`]`<`[`Backoff`]`>`.
+#[cfg(feature = "arc_lock")]
+pub type ArcBackoffRwSpinlockUpgradableReadGuard<T> =
+    lock_api::ArcRwLockUpgradableReadGuard<RawRwSpinlock<Backoff>, T>;
+
+/// A [`lock_api::ArcRwLockWriteGuard`] based on [`RawRwSpinlock`]`<`[`Backoff`]`>`.
+#[cfg(feature = "arc_lock")]
+pub type ArcBackoffRwSpinlockWriteGuard<T> =
+    lock_api::ArcRwLockWriteGuard<RawRwSpinlock<Backoff>, T>;
 
 // Adapted from `spin::rwlock`.
 #[cfg(test)]

--- a/src/spinlock.rs
+++ b/src/spinlock.rs
@@ -202,6 +202,10 @@ pub type SpinlockGuard<'a, T> = lock_api::MutexGuard<'a, RawSpinlock<Spin>, T>;
 /// ```
 pub type MappedSpinlockGuard<'a, T> = lock_api::MappedMutexGuard<'a, RawSpinlock<Spin>, T>;
 
+/// A [`lock_api::ArcMutexGuard`] based on [`RawSpinlock`]`.
+#[cfg(feature = "arc_lock")]
+pub type ArcSpinlockGuard<T> = lock_api::ArcMutexGuard<RawSpinlock<Spin>, T>;
+
 /// A mutual exclusion (Mutex) type based on busy-waiting with exponential backoff.
 ///
 /// Calling `lock` (or `try_lock`) on this type returns a [`BackoffSpinlockGuard`], which
@@ -309,6 +313,10 @@ pub type BackoffSpinlockGuard<'a, T> = lock_api::MutexGuard<'a, RawSpinlock<Back
 /// ```
 pub type MappedBackoffSpinlockGuard<'a, T> =
     lock_api::MappedMutexGuard<'a, RawSpinlock<Backoff>, T>;
+
+/// A [`lock_api::ArcMutexGuard`] based on [`RawSpinlock`]`<`[`Backoff`]`>`.
+#[cfg(feature = "arc_lock")]
+pub type ArcBackoffSpinlockGuard<T> = lock_api::ArcMutexGuard<RawSpinlock<Backoff>, T>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR has two commits:
1. Adding the `arc_lock` feature and corresponding typedefs.
2. Configuring docs.rs to
   - document all features
   - use `doc_auto_cfg` to annotate required features on types
   - enable `--generate-link-to-definition` for rustdoc sources

You can test this with the following command:

```
RUSTDOCFLAGS="-Zunstable-options --cfg=docsrs --generate-link-to-definition" cargo +nightly doc --open --all-features
```

Closes https://github.com/rust-osdev/spinning_top/issues/24