### PR TITLE
Prepare for v0.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ lock_api = "0.4.7"
 rand = "0.8"
 
 [package.metadata.release]
-dev-version = false
 pre-release-replacements = [
     { file = "Changelog.md", search = "# Unreleased", replace = "# Unreleased\n\n# {{version}} – {{date}}", exactly = 1 },
 ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,23 @@
 # Unreleased
 
+## Breaking
+
+* [feat: add backoff feature](https://github.com/rust-osdev/spinning_top/pull/16)
+* [chore: remove `const_spinlock` function](https://github.com/rust-osdev/spinning_top/pull/20)
+* [chore: remove deprecated `nightly` feature](https://github.com/rust-osdev/spinning_top/pull/21)
+
+## Improvements
+
+* [feat: add `RwSpinlock` readers-writer lock](https://github.com/rust-osdev/spinning_top/pull/18)
+* [feat: add `arc_lock` feature and typedefs](https://github.com/rust-osdev/spinning_top/pull/25)
+* [perf: inline everything](https://github.com/rust-osdev/spinning_top/pull/17)
+* [docs: fix typo](https://github.com/rust-osdev/spinning_top/pull/23)
+
+## Other
+
+* [ci: build with all features](https://github.com/rust-osdev/spinning_top/pull/19)
+* [test: don't ignore statics example](https://github.com/rust-osdev/spinning_top/pull/22)
+
 # 0.2.5 – 2023-02-24
 
 - Upgrade `lock_api` to 0.4.7. This makes `Spinlock::new` a `const` function without needing nightly rust.


### PR DESCRIPTION
- Update changelog
- Update cargo-release configuration to latest version
