### PR TITLE
fix(docsrs): migrate from `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! ```
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 


### PR DESCRIPTION
`dock_auto_cfg` was merged into `doc_cfg` in https://github.com/rust-lang/rust/pull/138907.